### PR TITLE
Prefix command, when executing non-builtin commands

### DIFF
--- a/z.fish
+++ b/z.fish
@@ -25,11 +25,11 @@ function z -d "Jump to a recent directory."
         # $HOME isn't worth matching
         [ "$argv" = "$HOME" ]; and return
 
-		set -l tempfile (mktemp $datafile.XXXXXX)
+		set -l tempfile (command mktemp $datafile.XXXXXX)
 		test -f $tempfile; or return
 		
         # maintain the file
-        awk -v path="$argv" -v now=(date +%s) -F"|" '
+        command awk -v path="$argv" -v now=(date +%s) -F"|" '
             BEGIN {
                 rank[path] = 1
                 time[path] = now
@@ -51,12 +51,12 @@ function z -d "Jump to a recent directory."
             }
         ' $datafile ^/dev/null > $tempfile
 
-        mv -f $tempfile $datafile
+        command mv -f $tempfile $datafile
 
     # tab completion
     else
         if [ "$argv[1]" = "--complete" ]
-            awk -v q="$argv[2]" -F"|" '
+            command awk -v q="$argv[2]" -F"|" '
                 BEGIN {
                     if( q == tolower(q) ) nocase = 1
                     split(q,fnd," ")
@@ -111,9 +111,9 @@ function z -d "Jump to a recent directory."
             # no file yet
             [ -f "$datafile" ]; or return
 
-			set -l tempfile (mktemp $datafile.XXXXXX)
-			test -f $tempfile; or return
-            set -l target (awk -v t=(date +%s) -v list="$list" -v typ="$typ" -v q="$fnd" -v tmpfl="$tempfile" -F"|" '
+            set -l tempfile (command mktemp $datafile.XXXXXX)
+            test -f $tempfile; or return
+            set -l target (command awk -v t=(date +%s) -v list="$list" -v typ="$typ" -v q="$fnd" -v tmpfl="$tempfile" -F"|" '
                 function frecent(rank, time) {
                     dx = t-time
                     if( dx < 3600 ) return rank*4
@@ -175,9 +175,9 @@ function z -d "Jump to a recent directory."
             ' "$datafile")
 
             if [ $status -gt 0 ]
-                rm -f "$tempfile"
+                command rm -f "$tempfile"
             else
-                mv -f "$tempfile" "$datafile"
+                command mv -f "$tempfile" "$datafile"
                 [ "$target" ]; and cd "$target"
             end
         end
@@ -185,9 +185,9 @@ function z -d "Jump to a recent directory."
 end	
 
 function __z_init -d 'Set up automatic population of the directory list for z'
-	functions fish_prompt | grep -q 'z --add'
+	functions fish_prompt | command grep -q 'z --add'
 	if [ $status -gt 0 ]
-		functions fish_prompt | sed -e '$ i\\
+		functions fish_prompt | command sed -e '$ i\\
 		z --add "$PWD"' | .
 	end
 end


### PR DESCRIPTION
This way custom functions/aliases, defined in the config.fish, don't mess up the plugin.
