### PR TITLE
Use `command rm` to allow for override of rm.

### DIFF
--- a/z.fish
+++ b/z.fish
@@ -175,7 +175,9 @@ function z -d "Jump to a recent directory."
             ' "$datafile")
 
             if [ $status -gt 0 ]
-                rm -f "$tempfile"
+                # This use of 'command' is to allow for an override of rm. 
+                # See https://github.com/fish-shell/fish-shell/issues/2663
+                command rm -f "$tempfile"
             else
                 mv -f "$tempfile" "$datafile"
                 [ "$target" ]; and cd "$target"


### PR DESCRIPTION
This is kind of an edge case but could prove useful to others and is harmless to add. The use case is that I have the trash command installed on my system and I write a wrapper around rm that disallows its use. This works great, but when I call z, it tries to call that wrapper and not the system rm. 

This is for those who follow the philosophy that rm should only be used in scripts and trash should be used instead for the interactive shell.

See https://github.com/fish-shell/fish-shell/issues/2663
