### PR TITLE
Support $XDG_DATA_HOME env variable for user-specific data

### DIFF
--- a/z.fish
+++ b/z.fish
@@ -20,7 +20,8 @@ function addzhist --on-variable PWD
 end
 
 function z -d "Jump to a recent directory."
-    set -l datafile "$HOME/.z"
+    set -l datafile "$XDG_DATA_HOME/z"
+    test -z "$XDG_DATA_HOME"; and set -l datafile "$HOME/.z"
 
     # add entries
     if [ "$argv[1]" = "--add" ]


### PR DESCRIPTION
[XDG Base Directory specification](https://specifications.freedesktop.org/basedir-spec/basedir-spec-latest.html) is a set of specifications for linux desktop application to save data to standard places.

This commit attempt to use $XDG_DATA_HOME if present, or else fallback to using the current $HOME directory.